### PR TITLE
Implement context menu and definitions view

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ At this stage of development the plugin provides a settings tab where you can st
 API keys for the dictionary and thesaurus endpoints. The code also includes helper
 functions for performing lookups using those keys.
 
+## Usage
+
+1. Install or clone this plugin into your vault.
+2. Open **Settings → Merriam-Webster Dictionary** and enter your API keys for the dictionary and thesaurus.
+3. Select a single word in an editor pane and open the context menu.
+4. Choose **Define** to open the side panel showing definitions and synonyms.
+5. Select a word from the **Synonyms** submenu to replace your selection.
+6. In the Definitions view you can type another word in the search field and press **Enter** to look it up.
+
+You can obtain free API keys from <https://www.dictionaryapi.com/>.
+
 ## First time developing plugins?
 
 Quick starting guide for new plugin devs:

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
-import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { App, Plugin, PluginSettingTab, Setting, Menu, WorkspaceLeaf } from 'obsidian';
 import { fetchDictionary, fetchThesaurus, DictionaryResult, ThesaurusResult } from './src/merriamWebsterApi';
+import DefinitionsView, { VIEW_TYPE_DEFINITIONS } from './src/definitionsView';
 
 interface MerriamWebsterPluginSettings {
   dictionaryApiKey: string;
@@ -14,9 +15,68 @@ const DEFAULT_SETTINGS: MerriamWebsterPluginSettings = {
 export default class MerriamWebsterPlugin extends Plugin {
   settings: MerriamWebsterPluginSettings;
 
+  async openDefinitionsView(word: string) {
+    let leaf: WorkspaceLeaf;
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_DEFINITIONS);
+    if (leaves.length > 0) {
+      leaf = leaves[0];
+    } else {
+      leaf = this.app.workspace.getRightLeaf(false) ?? this.app.workspace.getLeaf(true);
+      await leaf.setViewState({ type: VIEW_TYPE_DEFINITIONS, active: true });
+    }
+    const view = leaf.view as DefinitionsView;
+    await view.setWord(word);
+    this.app.workspace.revealLeaf(leaf);
+  }
+
   async onload() {
     await this.loadSettings();
+    this.registerView(VIEW_TYPE_DEFINITIONS, (leaf) => new DefinitionsView(leaf, this));
     this.addSettingTab(new MerriamWebsterSettingTab(this.app, this));
+
+    this.registerEvent(
+      this.app.workspace.on('editor-menu', async (menu, editor) => {
+        const selection = editor.getSelection().trim();
+        if (!selection || /\s/.test(selection)) {
+          return;
+        }
+        const word = selection;
+
+        menu.addItem((item) => {
+          item
+            .setTitle('Define')
+            .setIcon('book')
+            .onClick(() => {
+              this.openDefinitionsView(word);
+            });
+        });
+
+        try {
+          const syns = await this.lookupSynonyms(word);
+          if (syns.synonyms.length > 0) {
+            const subMenu = new Menu();
+            for (const s of syns.synonyms.sort()) {
+              subMenu.addItem((sub) =>
+                sub.setTitle(s).onClick(() => {
+                  editor.replaceSelection(s);
+                })
+              );
+            }
+            menu.addItem((item) => {
+              item.setTitle('Synonyms');
+              // @ts-ignore - setSubmenu is available at runtime
+              item.setSubmenu(subMenu);
+            });
+          }
+        } catch {
+          /* ignore errors */
+        }
+      })
+    );
+  }
+
+  onunload() {
+    this.app.workspace.detachLeavesOfType(VIEW_TYPE_DEFINITIONS);
   }
 
   async loadSettings() {

--- a/src/definitionsView.ts
+++ b/src/definitionsView.ts
@@ -1,0 +1,77 @@
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import type MerriamWebsterPlugin from '../main';
+import { DictionaryResult, ThesaurusResult } from './merriamWebsterApi';
+
+export const VIEW_TYPE_DEFINITIONS = 'merriam-webster-definitions';
+
+export default class DefinitionsView extends ItemView {
+  plugin: MerriamWebsterPlugin;
+  word: string = '';
+
+  constructor(leaf: WorkspaceLeaf, plugin: MerriamWebsterPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return VIEW_TYPE_DEFINITIONS;
+  }
+
+  getDisplayText(): string {
+    return 'Definitions';
+  }
+
+  async onOpen() {
+    this.containerEl.classList.add('mw-definitions-view');
+    this.render();
+  }
+
+  async setWord(word: string) {
+    this.word = word;
+    await this.render();
+  }
+
+  private async render() {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    const search = containerEl.createEl('input', { type: 'text' });
+    search.value = this.word;
+    search.placeholder = 'Look up word';
+    search.addEventListener('keydown', async (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        await this.setWord(search.value.trim());
+      }
+    });
+
+    if (!this.word) {
+      return;
+    }
+
+    const defsDiv = containerEl.createDiv('mw-definitions');
+    defsDiv.createEl('h3', { text: `Definitions of ${this.word}` });
+    try {
+      const defs: DictionaryResult = await this.plugin.lookupDefinitions(this.word);
+      const list = defsDiv.createEl('ul');
+      for (const d of defs.definitions) {
+        list.createEl('li', { text: d });
+      }
+    } catch (err) {
+      defsDiv.createEl('div', { text: String(err) });
+    }
+
+    const synDiv = containerEl.createDiv('mw-synonyms');
+    synDiv.createEl('h3', { text: 'Synonyms' });
+    try {
+      const syns: ThesaurusResult = await this.plugin.lookupSynonyms(this.word);
+      const list = synDiv.createEl('ul');
+      for (const s of syns.synonyms) {
+        list.createEl('li', { text: s });
+      }
+    } catch (err) {
+      synDiv.createEl('div', { text: String(err) });
+    }
+  }
+}
+

--- a/styles.css
+++ b/styles.css
@@ -6,3 +6,12 @@ available in the app when your plugin is enabled.
 If your plugin does not need CSS, delete this file.
 
 */
+
+.mw-definitions-view {
+  padding: 10px;
+}
+
+.mw-definitions-view input[type="text"] {
+  width: 100%;
+  margin-bottom: 1em;
+}


### PR DESCRIPTION
## Summary
- add `DefinitionsView` to display word definitions and synonyms
- register definitions view and context menu integration
- open definitions view from the context menu and show synonyms submenu
- add basic styling for the view
- document plugin usage in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68451bfe42a88326afb8e9e2a9bc2e0c