### PR TITLE
Add error notice for synonyms lookup

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, PluginSettingTab, Setting, Menu, WorkspaceLeaf } from 'obsidian';
+import { App, Plugin, PluginSettingTab, Setting, Menu, WorkspaceLeaf, Notice } from 'obsidian';
 import { fetchDictionary, fetchThesaurus, DictionaryResult, ThesaurusResult } from './src/merriamWebsterApi';
 import DefinitionsView, { VIEW_TYPE_DEFINITIONS } from './src/definitionsView';
 
@@ -68,8 +68,8 @@ export default class MerriamWebsterPlugin extends Plugin {
               item.setSubmenu(subMenu);
             });
           }
-        } catch {
-          /* ignore errors */
+        } catch (err) {
+          new Notice('Failed to fetch synonyms');
         }
       })
     );


### PR DESCRIPTION
## Summary
- import `Notice` from Obsidian
- notify the user when synonyms cannot be fetched

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68452215a4108326a9829b9df3e0798a