### PR TITLE
Add caching for dictionary and thesaurus lookups

### DIFF
--- a/src/merriamWebsterApi.ts
+++ b/src/merriamWebsterApi.ts
@@ -8,9 +8,19 @@ export interface ThesaurusResult {
   synonyms: string[];
 }
 
+// Simple in-memory caches for API responses keyed by word
+const dictionaryCache = new Map<string, DictionaryResult>();
+const thesaurusCache = new Map<string, ThesaurusResult>();
+
 export async function fetchDictionary(word: string, apiKey: string): Promise<DictionaryResult> {
   if (!apiKey) {
     throw new Error('Dictionary API key is missing');
+  }
+
+  const key = word.toLowerCase();
+  const cached = dictionaryCache.get(key);
+  if (cached) {
+    return cached;
   }
 
   const url = `https://www.dictionaryapi.com/api/v3/references/collegiate/json/${encodeURIComponent(word)}?key=${apiKey}`;
@@ -20,16 +30,26 @@ export async function fetchDictionary(word: string, apiKey: string): Promise<Dic
   }
   const json = await res.json();
   if (!Array.isArray(json) || json.length === 0) {
-    return { word, definitions: [] };
+    const result = { word, definitions: [] };
+    dictionaryCache.set(key, result);
+    return result;
   }
   const first = json[0];
   const defs = Array.isArray(first.shortdef) ? first.shortdef : [];
-  return { word, definitions: defs };
+  const result = { word, definitions: defs };
+  dictionaryCache.set(key, result);
+  return result;
 }
 
 export async function fetchThesaurus(word: string, apiKey: string): Promise<ThesaurusResult> {
   if (!apiKey) {
     throw new Error('Thesaurus API key is missing');
+  }
+
+  const key = word.toLowerCase();
+  const cached = thesaurusCache.get(key);
+  if (cached) {
+    return cached;
   }
 
   const url = `https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${encodeURIComponent(word)}?key=${apiKey}`;
@@ -39,11 +59,15 @@ export async function fetchThesaurus(word: string, apiKey: string): Promise<Thes
   }
   const json = await res.json();
   if (!Array.isArray(json) || json.length === 0) {
-    return { word, synonyms: [] };
+    const result = { word, synonyms: [] };
+    thesaurusCache.set(key, result);
+    return result;
   }
   const first = json[0];
   const syns = Array.isArray(first.meta?.syns)
     ? first.meta.syns.flat().sort()
     : [];
-  return { word, synonyms: syns };
+  const result = { word, synonyms: syns };
+  thesaurusCache.set(key, result);
+  return result;
 }


### PR DESCRIPTION
## Summary
- add simple in-memory caches for dictionary and thesaurus responses
- reuse cached entries in `fetchDictionary` and `fetchThesaurus`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845222090f883268b9e4203c516adba