### PR TITLE
Add build reminder documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Quick starting guide for new plugin devs:
 - `npm i` or `yarn` to install dependencies.
 - `npm run dev` to start compilation in watch mode.
 
+## Before committing
+
+Run `npm run build` once you are ready to commit changes. This command type-checks
+and bundles the plugin so you can catch errors before pushing your work.
+
 ## Manually installing the plugin
 
 - Copy over `main.js`, `styles.css`, `manifest.json` to your vault `VaultFolder/.obsidian/plugins/your-plugin-id/`.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"version": "node version-bump.mjs && git add manifest.json versions.json"
-	},
+                "version": "node version-bump.mjs && git add manifest.json versions.json",
+                "prepublishOnly": "npm run build"
+        },
 	"keywords": [],
 	"author": "",
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- remind developers to run `npm run build` before committing
- run build automatically on `npm publish`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845222082f8832689efb55e2572e850