### PR TITLE
Improve error detail for synonym lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ and bundles the plugin so you can catch errors before pushing your work.
 
 If definitions or synonyms fail to load, check your API keys and network connectivity.
 Make sure the plugin was rebuilt (`npm run build`) before copying files to your vault.
+When right-clicking a word, any error received while fetching synonyms will now be shown in the notice popup. Check this message and the developer console for clues if lookups continue to fail.
 
 ## Manually installing the plugin
 

--- a/main.ts
+++ b/main.ts
@@ -68,7 +68,9 @@ export default class MerriamWebsterPlugin extends Plugin {
             });
           }
         } catch (err) {
-          new Notice('Failed to fetch synonyms');
+          console.error('Failed to fetch synonyms', err);
+          const msg = err instanceof Error ? err.message : String(err);
+          new Notice(`Failed to fetch synonyms: ${msg}`);
         }
       })
     );


### PR DESCRIPTION
## Summary
- display error details when synonym lookup fails
- document how synonym errors are surfaced

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68452e5ad6008326872458aef769d9e7