### PR TITLE
Improve Merriam-Webster context menus

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -46,6 +46,7 @@ export default class MerriamWebsterPlugin extends Plugin {
           item
             .setTitle('Define')
             .setIcon('book')
+            .setSection('mw-dictionary')
             .onClick(() => {
               this.openDefinitionsView(word);
             });
@@ -63,8 +64,11 @@ export default class MerriamWebsterPlugin extends Plugin {
               );
             }
             menu.addItem((item) => {
-              item.setTitle('Synonyms');
-              item.setSubmenu(subMenu);
+              item
+                .setTitle('Synonyms')
+                .setIcon('pencil')
+                .setSection('mw-dictionary')
+                .setSubmenu(subMenu);
             });
           }
         } catch (err) {

--- a/src/definitionsView.ts
+++ b/src/definitionsView.ts
@@ -18,7 +18,11 @@ export default class DefinitionsView extends ItemView {
   }
 
   getDisplayText(): string {
-    return 'Definitions';
+    return 'Definitions View';
+  }
+
+  getIcon(): string {
+    return 'book';
   }
 
   async onOpen() {
@@ -50,12 +54,19 @@ export default class DefinitionsView extends ItemView {
     }
 
     const defsDiv = containerEl.createDiv('mw-definitions');
-    defsDiv.createEl('h3', { text: `Definitions of ${this.word}` });
     try {
       const defs: DictionaryResult = await this.plugin.lookupDefinitions(this.word);
-      const list = defsDiv.createEl('ul');
+      defsDiv.createEl('h3', { text: this.word });
+      if (defs.wordType) {
+        defsDiv.createEl('h4', { text: defs.wordType });
+      }
+      if (defs.pluralForm) {
+        defsDiv.createEl('div', { text: `Plural: ${defs.pluralForm}` });
+      }
+      const list = defsDiv.createEl('ol');
       for (const d of defs.definitions) {
-        list.createEl('li', { text: d });
+        const clean = d.charAt(0).toUpperCase() + d.slice(1);
+        list.createEl('li', { text: clean });
       }
     } catch (err) {
       defsDiv.createEl('div', { text: String(err) });
@@ -67,7 +78,11 @@ export default class DefinitionsView extends ItemView {
       const syns: ThesaurusResult = await this.plugin.lookupSynonyms(this.word);
       const list = synDiv.createEl('ul');
       for (const s of syns.synonyms) {
-        list.createEl('li', { text: s });
+        const li = list.createEl('li');
+        const btn = li.createEl('button', { text: s });
+        btn.addEventListener('click', () => {
+          this.setWord(s);
+        });
       }
     } catch (err) {
       synDiv.createEl('div', { text: String(err) });


### PR DESCRIPTION
## Summary
- label Definitions view correctly and add icon
- position Define/Synonyms actions at top of editor menu
- show word type and plural info
- number definitions and capitalize entries
- allow synonyms list to trigger lookups

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68453155ccc48326b3ff447e33994c14