### PR TITLE
Update synonyms menu behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ functions for performing lookups using those keys.
 2. Open **Settings → Merriam-Webster Dictionary** and enter your API keys for the dictionary and thesaurus.
 3. Select a single word in an editor pane and open the context menu.
 4. Choose **Define** to open the side panel showing definitions and synonyms.
-5. Select a word from the **Synonyms** submenu to replace your selection.
+5. Up to five suggested synonyms appear above **Define** in the context menu. Select one to replace your selection.
 6. In the Definitions view you can type another word in the search field and press **Enter** to look it up.
 
 You can obtain free API keys from <https://www.dictionaryapi.com/>.

--- a/styles.css
+++ b/styles.css
@@ -55,3 +55,8 @@ If your plugin does not need CSS, delete this file.
 .mw-synonyms li {
   margin-bottom: 0.25em;
 }
+
+/* Context menu synonym items */
+.menu-item.mw-synonym-item {
+  background-color: var(--text-highlight-bg);
+}


### PR DESCRIPTION
## Summary
- fetch synonyms when opening the context menu
- list up to 5 synonyms directly in the menu before **Define**
- highlight synonym options with the theme highlight color
- document new synonym selection in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684536254cbc83268f15e2e3eff9a01f