### PR TITLE
Update synonyms menu delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ functions for performing lookups using those keys.
 2. Open **Settings → Merriam-Webster Dictionary** and enter your API keys for the dictionary and thesaurus.
 3. Select a single word in an editor pane and open the context menu.
 4. Choose **Define** to open the side panel showing definitions and synonyms.
-5. Select a word from the **Synonyms** submenu to replace your selection.
+5. Up to five suggested synonyms appear above **Define** in the context menu. Select one to replace your selection. The menu waits briefly for these suggestions, so they may not appear if the lookup takes too long.
 6. In the Definitions view you can type another word in the search field and press **Enter** to look it up.
 
 You can obtain free API keys from <https://www.dictionaryapi.com/>.

--- a/main.ts
+++ b/main.ts
@@ -42,6 +42,32 @@ export default class MerriamWebsterPlugin extends Plugin {
         }
         const word = selection;
 
+        try {
+          const syns = await Promise.race([
+            this.lookupSynonyms(word),
+            new Promise<null>((resolve) => setTimeout(() => resolve(null), 1000)),
+          ]);
+          if (syns) {
+            const list = syns.synonyms.slice(0, 5).sort();
+            for (const s of list) {
+              menu.addItem((item) => {
+                item
+                  .setTitle(s)
+                  .setIcon('pencil')
+                  .setSection('mw-dictionary')
+                  .onClick(() => {
+                    editor.replaceSelection(s);
+                  });
+                (item as any).dom?.addClass('mw-synonym-item');
+              });
+            }
+          }
+        } catch (err) {
+          console.error('Failed to fetch synonyms', err);
+          const msg = err instanceof Error ? err.message : String(err);
+          new Notice(`Failed to fetch synonyms: ${msg}`);
+        }
+
         menu.addItem((item) => {
           item
             .setTitle('Define')
@@ -51,31 +77,6 @@ export default class MerriamWebsterPlugin extends Plugin {
               this.openDefinitionsView(word);
             });
         });
-
-        try {
-          const syns = await this.lookupSynonyms(word);
-          if (syns.synonyms.length > 0) {
-            const subMenu = new Menu();
-            for (const s of syns.synonyms.sort()) {
-              subMenu.addItem((sub) =>
-                sub.setTitle(s).onClick(() => {
-                  editor.replaceSelection(s);
-                })
-              );
-            }
-            menu.addItem((item) => {
-              item
-                .setTitle('Synonyms')
-                .setIcon('pencil')
-                .setSection('mw-dictionary')
-                .setSubmenu(subMenu);
-            });
-          }
-        } catch (err) {
-          console.error('Failed to fetch synonyms', err);
-          const msg = err instanceof Error ? err.message : String(err);
-          new Notice(`Failed to fetch synonyms: ${msg}`);
-        }
       })
     );
   }

--- a/styles.css
+++ b/styles.css
@@ -55,3 +55,8 @@ If your plugin does not need CSS, delete this file.
 .mw-synonyms li {
   margin-bottom: 0.25em;
 }
+
+/* Context menu synonym items */
+.menu-item.mw-synonym-item {
+  background-color: var(--text-highlight-bg);
+}


### PR DESCRIPTION
## Summary
- wait up to a second for synonyms before building the context menu
- document that synonym suggestions may not appear if the lookup is slow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684536254cbc83268f15e2e3eff9a01f