### PR TITLE
Fix context menu define option and remove synonyms lookup

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -42,32 +42,6 @@ export default class MerriamWebsterPlugin extends Plugin {
         }
         const word = selection;
 
-        try {
-          const syns = await Promise.race([
-            this.lookupSynonyms(word),
-            new Promise<null>((resolve) => setTimeout(() => resolve(null), 1000)),
-          ]);
-          if (syns) {
-            const list = syns.synonyms.slice(0, 5).sort();
-            for (const s of list) {
-              menu.addItem((item) => {
-                item
-                  .setTitle(s)
-                  .setIcon('pencil')
-                  .setSection('mw-dictionary')
-                  .onClick(() => {
-                    editor.replaceSelection(s);
-                  });
-                (item as any).dom?.addClass('mw-synonym-item');
-              });
-            }
-          }
-        } catch (err) {
-          console.error('Failed to fetch synonyms', err);
-          const msg = err instanceof Error ? err.message : String(err);
-          new Notice(`Failed to fetch synonyms: ${msg}`);
-        }
-
         menu.addItem((item) => {
           item
             .setTitle('Define')


### PR DESCRIPTION
## Summary
- remove right-click synonyms lookup logic from `main.ts`
- keep context-menu item that opens the Definitions View

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684540ab0938832695b76492e8d7bf98