### PR TITLE
Improve definitions display and styling

### DIFF
--- a/src/definitionsView.ts
+++ b/src/definitionsView.ts
@@ -64,16 +64,25 @@ export default class DefinitionsView extends ItemView {
     try {
       const defs: DictionaryResult = await this.plugin.lookupDefinitions(this.word);
       defsDiv.createEl('h3', { text: toTitleCase(this.word) });
-      if (defs.wordType) {
-        defsDiv.createEl('h4', { text: defs.wordType });
-      }
       if (defs.pluralForm) {
         defsDiv.createEl('div', { text: `Plural: ${defs.pluralForm}` });
       }
-      const list = defsDiv.createEl('ol');
-      for (const d of defs.definitions) {
-        const clean = d.charAt(0).toUpperCase() + d.slice(1);
-        list.createEl('li', { text: clean });
+      for (const entry of defs.entries) {
+        if (entry.wordType) {
+          defsDiv.createEl('h4', { text: entry.wordType });
+        }
+        const list = defsDiv.createEl('ol');
+        for (const d of entry.definitions) {
+          const clean = d.charAt(0).toUpperCase() + d.slice(1);
+          list.createEl('li', { text: clean });
+        }
+        if (entry.examples.length > 0) {
+          defsDiv.createEl('h5', { text: 'Usage' });
+          const usage = defsDiv.createEl('ul');
+          for (const ex of entry.examples) {
+            usage.createEl('li', { text: ex });
+          }
+        }
       }
     } catch (err) {
       defsDiv.createEl('div', { text: String(err) });

--- a/src/merriamWebsterApi.ts
+++ b/src/merriamWebsterApi.ts
@@ -1,8 +1,13 @@
+export interface DictionaryEntry {
+  wordType?: string;
+  definitions: string[];
+  examples: string[];
+}
+
 export interface DictionaryResult {
   word: string;
-  definitions: string[];
-  wordType?: string;
   pluralForm?: string;
+  entries: DictionaryEntry[];
 }
 
 export interface ThesaurusResult {
@@ -13,6 +18,58 @@ export interface ThesaurusResult {
 // Simple in-memory caches for API responses keyed by word
 const dictionaryCache = new Map<string, DictionaryResult>();
 const thesaurusCache = new Map<string, ThesaurusResult>();
+
+function stripFormatting(text: string): string {
+  return text.replace(/\{[^}]+\}/g, '');
+}
+
+function extractExamples(entry: any): string[] {
+  const examples: string[] = [];
+
+  function extractFromDt(dtList: any[]): void {
+    for (const dt of dtList) {
+      if (!Array.isArray(dt) || dt.length < 2) continue;
+      const type = dt[0];
+      const data = dt[1];
+      if (type === 'vis' && Array.isArray(data)) {
+        for (const v of data) {
+          if (v && typeof v.t === 'string') {
+            examples.push(stripFormatting(v.t));
+          }
+        }
+      } else if (Array.isArray(data)) {
+        extractFromDt(data);
+      } else if (data && typeof data === 'object' && Array.isArray(data.dt)) {
+        extractFromDt(data.dt);
+      }
+    }
+  }
+
+  if (Array.isArray(entry.def)) {
+    for (const d of entry.def) {
+      if (Array.isArray(d.sseq)) {
+        for (const seq of d.sseq) {
+          for (const sense of seq) {
+            if (Array.isArray(sense) && sense.length >= 2) {
+              const data = sense[1];
+              if (data) {
+                if (Array.isArray(data.dt)) extractFromDt(data.dt);
+                if (data.sdsense) {
+                  if (Array.isArray(data.sdsense.dt)) extractFromDt(data.sdsense.dt);
+                }
+                if (data.sense && Array.isArray(data.sense.dt)) {
+                  extractFromDt(data.sense.dt);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return examples;
+}
 
 export async function fetchDictionary(word: string, apiKey: string): Promise<DictionaryResult> {
   if (!apiKey) {
@@ -32,30 +89,39 @@ export async function fetchDictionary(word: string, apiKey: string): Promise<Dic
   }
   const json = await res.json();
   if (!Array.isArray(json) || json.length === 0) {
-    const result = { word, definitions: [] } as DictionaryResult;
+    const result: DictionaryResult = { word, entries: [] };
     dictionaryCache.set(key, result);
     return result;
   }
-  const first = json[0];
-  const defs = Array.isArray(first.shortdef) ? first.shortdef : [];
-  const wordType = typeof first.fl === 'string' ? first.fl : undefined;
+
   let pluralForm: string | undefined;
-  const inflections =
-    first.ins ?? first.hwi?.ins ?? first.def?.[0]?.sseq?.[0]?.[0]?.[1]?.ins;
-  if (Array.isArray(inflections)) {
-    const plural = inflections.find(
-      (i: any) => typeof i.il === 'string' && i.il.toLowerCase().includes('plural')
-    );
-    if (plural && typeof plural.if === 'string') {
-      pluralForm = plural.if;
+  const entries: DictionaryEntry[] = [];
+
+  for (const item of json) {
+    if (!item || typeof item !== 'object' || !Array.isArray(item.shortdef)) {
+      continue;
     }
+
+    if (!pluralForm) {
+      const inflections =
+        item.ins ?? item.hwi?.ins ?? item.def?.[0]?.sseq?.[0]?.[0]?.[1]?.ins;
+      if (Array.isArray(inflections)) {
+        const plural = inflections.find(
+          (i: any) => typeof i.il === 'string' && i.il.toLowerCase().includes('plural')
+        );
+        if (plural && typeof plural.if === 'string') {
+          pluralForm = plural.if;
+        }
+      }
+    }
+
+    const definitions = item.shortdef as string[];
+    const wordType = typeof item.fl === 'string' ? item.fl : undefined;
+    const examples = extractExamples(item);
+    entries.push({ wordType, definitions, examples });
   }
-  const result: DictionaryResult = {
-    word,
-    definitions: defs,
-    wordType,
-    pluralForm,
-  };
+
+  const result: DictionaryResult = { word, entries, pluralForm };
   dictionaryCache.set(key, result);
   return result;
 }

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,7 @@ If your plugin does not need CSS, delete this file.
   font-family: var(--mw-font-family);
   font-size: var(--mw-font-size);
   color: var(--mw-text-color);
+  overflow-y: auto;
 }
 
 .mw-definitions-view input[type="text"] {
@@ -60,10 +61,14 @@ If your plugin does not need CSS, delete this file.
   list-style-type: none;
   margin: 0 0 0.5em 0;
   padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25em;
 }
 
 .mw-definitions li,
 .mw-synonyms li {
   margin-bottom: 0.25em;
+  margin-right: 0.25em;
 }
 


### PR DESCRIPTION
## Summary
- show all dictionary entries in sequence, each with their own part of speech
- display usage examples when available from the API
- allow content scrolling and horizontal synonym layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684544a5bee4832686729eef1c7c8360