### PR TITLE
Improve Definitions View formatting

### DIFF
--- a/src/merriamWebsterApi.ts
+++ b/src/merriamWebsterApi.ts
@@ -6,13 +6,18 @@ export interface DictionaryEntry {
 
 export interface DictionaryResult {
   word: string;
-  pluralForm?: string;
+  pluralForms?: string[];
   entries: DictionaryEntry[];
+}
+
+export interface ThesaurusSynonym {
+  word: string;
+  label?: string;
 }
 
 export interface ThesaurusResult {
   word: string;
-  synonyms: string[];
+  synonyms: ThesaurusSynonym[];
 }
 
 // Simple in-memory caches for API responses keyed by word
@@ -94,7 +99,7 @@ export async function fetchDictionary(word: string, apiKey: string): Promise<Dic
     return result;
   }
 
-  let pluralForm: string | undefined;
+  const pluralForms: string[] = [];
   const entries: DictionaryEntry[] = [];
 
   for (const item of json) {
@@ -102,15 +107,16 @@ export async function fetchDictionary(word: string, apiKey: string): Promise<Dic
       continue;
     }
 
-    if (!pluralForm) {
-      const inflections =
-        item.ins ?? item.hwi?.ins ?? item.def?.[0]?.sseq?.[0]?.[0]?.[1]?.ins;
-      if (Array.isArray(inflections)) {
-        const plural = inflections.find(
-          (i: any) => typeof i.il === 'string' && i.il.toLowerCase().includes('plural')
-        );
-        if (plural && typeof plural.if === 'string') {
-          pluralForm = plural.if;
+    const inflections =
+      item.ins ?? item.hwi?.ins ?? item.def?.[0]?.sseq?.[0]?.[0]?.[1]?.ins;
+    if (Array.isArray(inflections)) {
+      for (const infl of inflections) {
+        if (
+          typeof infl.il === 'string' &&
+          infl.il.toLowerCase().includes('plural') &&
+          typeof infl.if === 'string'
+        ) {
+          pluralForms.push(infl.if);
         }
       }
     }
@@ -121,7 +127,7 @@ export async function fetchDictionary(word: string, apiKey: string): Promise<Dic
     entries.push({ wordType, definitions, examples });
   }
 
-  const result: DictionaryResult = { word, entries, pluralForm };
+  const result: DictionaryResult = { word, entries, pluralForms: pluralForms.length > 0 ? Array.from(new Set(pluralForms)) : undefined };
   dictionaryCache.set(key, result);
   return result;
 }
@@ -149,10 +155,43 @@ export async function fetchThesaurus(word: string, apiKey: string): Promise<Thes
     return result;
   }
   const first = json[0];
-  const syns = Array.isArray(first.meta?.syns)
-    ? first.meta.syns.flat().sort()
-    : [];
-  const result = { word, synonyms: syns };
+  const synonyms: ThesaurusSynonym[] = [];
+
+  function extractSynList(entry: any): void {
+    if (!entry || !Array.isArray(entry.def)) return;
+    for (const d of entry.def) {
+      if (!Array.isArray(d.sseq)) continue;
+      for (const seq of d.sseq) {
+        for (const sense of seq) {
+          if (Array.isArray(sense) && sense.length >= 2) {
+            const data = sense[1];
+            if (data && Array.isArray(data.syn_list)) {
+              for (const group of data.syn_list) {
+                for (const syn of group) {
+                  if (syn && typeof syn.wd === 'string') {
+                    const label = syn.wsls?.wsl as string | undefined;
+                    synonyms.push({ word: syn.wd, label });
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  extractSynList(first);
+
+  if (synonyms.length === 0 && Array.isArray(first.meta?.syns)) {
+    for (const s of first.meta.syns.flat()) {
+      if (typeof s === 'string') {
+        synonyms.push({ word: s });
+      }
+    }
+  }
+
+  const result = { word, synonyms };
   thesaurusCache.set(key, result);
   return result;
 }

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,46 @@ If your plugin does not need CSS, delete this file.
   font-size: 0.9em;
 }
 
+.mw-definitions h5 {
+  margin-top: 0.5em;
+  margin-bottom: 0.25em;
+  font-size: 0.8em;
+}
+
+.mw-entry-list {
+  margin-left: 1em;
+}
+
+.mw-entry-list > li {
+  margin-bottom: 0.5em;
+}
+
+.mw-entry-list ol {
+  list-style-type: lower-alpha;
+  margin-left: 1.25em;
+}
+
+.mw-word-btn {
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  padding: 2px 6px;
+  background-color: var(--interactive-accent);
+  color: var(--text-on-accent);
+}
+
+.mw-word-btn-formal {
+  background-color: color-mix(in srgb, var(--interactive-accent) 50%, #a79c8a);
+}
+
+.mw-word-btn-archaic {
+  background-color: color-mix(in srgb, var(--interactive-accent) 70%, #000000);
+}
+
+.mw-word-btn-literary {
+  background-color: color-mix(in srgb, var(--interactive-accent) 50%, var(--text-accent));
+}
+
 .mw-definitions ul {
   list-style-type: disc;
   margin: 0 0 0.5em 1.25em;


### PR DESCRIPTION
## Summary
- support multiple plural forms in dictionary results
- parse thesaurus labels from `syn_list` and expose them for styling
- show plural forms and buttonized single-word definitions in the panel
- highlight looked-up word in usage examples
- style synonym buttons based on formal/archaic/literary labels

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845af1efed88326a83e467c8eddd236