### PR TITLE
Add settings updates and status colors

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,11 +5,15 @@ import DefinitionsView, { VIEW_TYPE_DEFINITIONS } from './src/definitionsView';
 interface MerriamWebsterPluginSettings {
   dictionaryApiKey: string;
   thesaurusApiKey: string;
+  synonymsOnTop: boolean;
+  cacheSize: number;
 }
 
 const DEFAULT_SETTINGS: MerriamWebsterPluginSettings = {
   dictionaryApiKey: '',
   thesaurusApiKey: '',
+  synonymsOnTop: false,
+  cacheSize: 0,
 };
 
 export default class MerriamWebsterPlugin extends Plugin {
@@ -174,5 +178,33 @@ class MerriamWebsterSettingTab extends PluginSettingTab {
         }
       });
     });
+
+    new Setting(containerEl)
+      .setName('Synonyms on Top')
+      .setDesc('Show the synonyms section above definitions')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.synonymsOnTop)
+          .onChange(async (value) => {
+            this.plugin.settings.synonymsOnTop = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Cache size')
+      .addText((text) => {
+        text.inputEl.type = 'number';
+        text.inputEl.step = '1';
+        text.inputEl.style.width = '6em';
+        text
+          .setPlaceholder('0')
+          .setValue(String(this.plugin.settings.cacheSize))
+          .onChange(async (value) => {
+            const parsed = parseInt(value);
+            this.plugin.settings.cacheSize = isNaN(parsed) ? 0 : parsed;
+            await this.plugin.saveSettings();
+          });
+      });
   }
 }

--- a/src/definitionsView.ts
+++ b/src/definitionsView.ts
@@ -60,7 +60,15 @@ export default class DefinitionsView extends ItemView {
       return;
     }
 
-    const defsDiv = containerEl.createDiv('mw-definitions');
+    let defsDiv: HTMLDivElement;
+    let synDiv: HTMLDivElement;
+    if (this.plugin.settings.synonymsOnTop) {
+      synDiv = containerEl.createDiv('mw-synonyms');
+      defsDiv = containerEl.createDiv('mw-definitions');
+    } else {
+      defsDiv = containerEl.createDiv('mw-definitions');
+      synDiv = containerEl.createDiv('mw-synonyms');
+    }
     try {
       const defs: DictionaryResult = await this.plugin.lookupDefinitions(this.word);
       defsDiv.createEl('h3', { text: toTitleCase(this.word) });
@@ -88,7 +96,6 @@ export default class DefinitionsView extends ItemView {
       defsDiv.createEl('div', { text: String(err) });
     }
 
-    const synDiv = containerEl.createDiv('mw-synonyms');
     synDiv.createEl('h3', { text: 'Synonyms' });
     try {
       const syns: ThesaurusResult = await this.plugin.lookupSynonyms(this.word);

--- a/styles.css
+++ b/styles.css
@@ -72,3 +72,11 @@ If your plugin does not need CSS, delete this file.
   margin-right: 0.25em;
 }
 
+.mw-api-status.success {
+  color: green;
+}
+
+.mw-api-status.error {
+  color: red;
+}
+


### PR DESCRIPTION
## Summary
- allow placing synonyms section at the top of the definitions view
- provide unused cache size option
- color API key validation success and error messages

## Testing
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b037c62c8326a20282749a067898