### PR TITLE
Add cache log for recent lookups

### DIFF
--- a/src/definitionsView.ts
+++ b/src/definitionsView.ts
@@ -66,6 +66,8 @@ export default class DefinitionsView extends ItemView {
 
     let defsDiv: HTMLDivElement;
     let synDiv: HTMLDivElement;
+    let defs: DictionaryResult;
+    let syns: ThesaurusResult;
     if (this.plugin.settings.synonymsOnTop) {
       synDiv = containerEl.createDiv('mw-synonyms');
       defsDiv = containerEl.createDiv('mw-definitions');
@@ -74,7 +76,7 @@ export default class DefinitionsView extends ItemView {
       synDiv = containerEl.createDiv('mw-synonyms');
     }
     try {
-      const defs: DictionaryResult = await this.plugin.lookupDefinitions(this.word);
+      ({ defs, syns } = await this.plugin.lookupWord(this.word));
       defsDiv.createEl('h3', { text: toTitleCase(this.word) });
 
       if (defs.pluralForms && defs.pluralForms.length > 0) {
@@ -132,11 +134,11 @@ export default class DefinitionsView extends ItemView {
       }
     } catch (err) {
       defsDiv.createEl('div', { text: String(err) });
+      return;
     }
 
     synDiv.createEl('h3', { text: 'Synonyms' });
     try {
-      const syns: ThesaurusResult = await this.plugin.lookupSynonyms(this.word);
       const list = synDiv.createEl('ul');
       for (const s of syns.synonyms) {
         const li = list.createEl('li');


### PR DESCRIPTION
## Summary
- extend settings to store recent query cache
- keep cache size non-negative and trim when size decreases
- fetch dictionary and thesaurus together to update cache
- render view from cached lookup info
- display current cache file size under cache size setting

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845b1a6ce948326ad2978bad6362b2e