### PR TITLE
Adjust button color and spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,7 @@ If your plugin does not need CSS, delete this file.
   font-family: var(--mw-font-family);
   font-size: var(--mw-font-size);
   color: var(--mw-text-color);
+  line-height: 1.2;
   overflow-y: auto;
 }
 
@@ -82,20 +83,21 @@ If your plugin does not need CSS, delete this file.
   border: none;
   border-radius: 4px;
   padding: 2px 6px;
-  background-color: var(--interactive-accent);
-  color: var(--text-on-accent);
+  background-color: var(--interactive-accent) !important;
+  color: var(--text-on-accent) !important;
+  line-height: 1;
 }
 
 .mw-word-btn-formal {
-  background-color: color-mix(in srgb, var(--interactive-accent) 50%, #a79c8a);
+  filter: brightness(85%) !important;
 }
 
 .mw-word-btn-archaic {
-  background-color: color-mix(in srgb, var(--interactive-accent) 70%, #000000);
+  filter: brightness(70%) !important;
 }
 
 .mw-word-btn-literary {
-  background-color: color-mix(in srgb, var(--interactive-accent) 50%, var(--text-accent));
+  filter: saturate(120%) !important;
 }
 
 .mw-definitions ul {


### PR DESCRIPTION
## Summary
- make the definitions view denser by adjusting line-height
- force word button colors so theme styles don't override them
- dim archaic/literary/formal buttons and tighten button line-height

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845bf24cd288326b2e513543721a652